### PR TITLE
fix: update macOS PATH for xPack GNU RISC-V Embedded GCC installation

### DIFF
--- a/website/docs/install/_common/_content.mdx
+++ b/website/docs/install/_common/_content.mdx
@@ -341,7 +341,7 @@ corresponding shell.
 <TabItem value="macos" label="macOS">
 
 <CodeBlock language="sh"> {
-`export PATH=$HOME/Library/xPacks/xpack-dev-tools/riscv-none-elf-gcc/14.2.0-3.1/.content/bin:$PATH
+`export PATH=$HOME/Library/xPacks/@xpack-dev-tools/riscv-none-elf-gcc/14.2.0-3.1/.content/bin:$PATH
 `} </CodeBlock>
 
 </TabItem>


### PR DESCRIPTION
# fix: update macOS PATH for xPack GNU RISC-V Embedded GCC installation

## Summary
Corrects the macOS installation PATH for xPack GNU RISC-V Embedded GCC in the documentation.

## Problem
The documentation provided an incorrect PATH for macOS users installing xPack GNU RISC-V Embedded GCC. The PATH was missing the `@` prefix in the `@xpack-dev-tools` directory name, which would cause the binaries to not be found when users followed the installation instructions.

## Changes
- Updated the macOS PATH export command in `website/docs/install/_common/_content.mdx:344`
- Changed from: `$HOME/Library/xPacks/xpack-dev-tools/riscv-none-elf-gcc/...`
- Changed to: `$HOME/Library/xPacks/@xpack-dev-tools/riscv-none-elf-gcc/...`

## Impact
This fix ensures macOS users can correctly add the RISC-V toolchain to their PATH after installation, allowing them to access the GCC binaries without errors.
